### PR TITLE
macOS menu bar app that unloads Mail attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+xcuserdata/
+DerivedData/

--- a/Unload Attachments.xcodeproj/project.pbxproj
+++ b/Unload Attachments.xcodeproj/project.pbxproj
@@ -7,25 +7,79 @@
 	objects = {
 
 /* Begin PBXFileReference section */
+		6224484A3037454E006DD8E3 /* Unload Attachments.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Unload Attachments.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		62E0517830373A0B00FF6C1E /* Unload.applescript */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.applescript; path = Unload.applescript; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		6224484C3037454E006DD8E3 /* Unload Attachments */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Unload Attachments";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		622448473037454E006DD8E3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+			);
+		};
+/* End PBXFrameworksBuildPhase section */
+
 /* Begin PBXGroup section */
+		6224484B3037454E006DD8E3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6224484A3037454E006DD8E3 /* Unload Attachments.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		62E051713037395D00FF6C1E = {
 			isa = PBXGroup;
 			children = (
 				62E0517830373A0B00FF6C1E /* Unload.applescript */,
+				6224484C3037454E006DD8E3 /* Unload Attachments */,
+				6224484B3037454E006DD8E3 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		622448493037454E006DD8E3 /* Unload Attachments */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6224485530374550006DD8E3 /* Build configuration list for PBXNativeTarget "Unload Attachments" */;
+			buildPhases = (
+				622448463037454E006DD8E3 /* Sources */,
+				622448473037454E006DD8E3 /* Frameworks */,
+				622448483037454E006DD8E3 /* Resources */,
+			);
+			buildRules = (
+			);
+			fileSystemSynchronizedGroups = (
+				6224484C3037454E006DD8E3 /* Unload Attachments */,
+			);
+			name = "Unload Attachments";
+			productName = "Unload Attachments";
+			productReference = 6224484A3037454E006DD8E3 /* Unload Attachments.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		62E051723037395D00FF6C1E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2700;
 				LastUpgradeCheck = 2700;
+				TargetAttributes = {
+					622448493037454E006DD8E3 = {
+						CreatedOnToolsVersion = 27.0;
+					};
+				};
 			};
 			buildConfigurationList = 62E051753037395D00FF6C1E /* Build configuration list for PBXProject "Unload Attachments" */;
 			developmentRegion = en;
@@ -37,14 +91,208 @@
 			mainGroup = 62E051713037395D00FF6C1E;
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 6224484B3037454E006DD8E3 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				622448493037454E006DD8E3 /* Unload Attachments */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		622448483037454E006DD8E3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		622448463037454E006DD8E3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXSourcesBuildPhase section */
+
 /* Begin XCBuildConfiguration section */
+		6224485330374550006DD8E3 /* Debug configuration for PBXNativeTarget "Unload Attachments" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = L527M49YJ9;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Unload Attachments controls Mail to save attachments from new messages and remove them from the original email.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jerfiss.Unload-Attachments";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		6224485430374550006DD8E3 /* Release configuration for PBXNativeTarget "Unload Attachments" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = L527M49YJ9;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Unload Attachments controls Mail to save attachments from new messages and remove them from the original email.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jerfiss.Unload-Attachments";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		62E051763037395D00FF6C1E /* Debug configuration for PBXProject "Unload Attachments" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -62,6 +310,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		6224485530374550006DD8E3 /* Build configuration list for PBXNativeTarget "Unload Attachments" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6224485330374550006DD8E3 /* Debug configuration for PBXNativeTarget "Unload Attachments" */,
+				6224485430374550006DD8E3 /* Release configuration for PBXNativeTarget "Unload Attachments" */,
+			);
+			defaultConfigurationName = Release;
+		};
 		62E051753037395D00FF6C1E /* Build configuration list for PBXProject "Unload Attachments" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Unload Attachments/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Unload Attachments/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Unload Attachments/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Unload Attachments/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Unload Attachments/Assets.xcassets/Contents.json
+++ b/Unload Attachments/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Unload Attachments/AttachmentUnloader.swift
+++ b/Unload Attachments/AttachmentUnloader.swift
@@ -3,7 +3,7 @@ import OSLog
 
 struct AttachmentRecord {
     enum Status {
-        case saved(URL, publishedURL: URL?)
+        case saved(URL, publishedURL: URL?, removed: Bool)
         case failed(String)
         case leftInPlace
     }
@@ -89,6 +89,7 @@ enum AttachmentUnloader {
         var savedCount = 0
         var failedCount = 0
         var failureReasons: [String] = []
+        var messageSourceCache: String?
 
         for attachment in message.attachments {
             let sizeText = formatter.string(fromByteCount: Int64(attachment.fileSize))
@@ -108,7 +109,21 @@ enum AttachmentUnloader {
                 defer { try? FileManager.default.removeItem(at: staging) }
 
                 let stagedFile = staging.appendingPathComponent(attachment.name)
-                try MailBridge.saveAttachment(messageID: message.id, attachmentID: attachment.id, toFile: stagedFile)
+                do {
+                    try MailBridge.saveAttachment(messageID: message.id, attachmentID: attachment.id, toFile: stagedFile)
+                } catch {
+                    // Mail's scripted save is broken on modern macOS (-10000);
+                    // extract the attachment from the raw message source instead.
+                    logger.notice("Scripted save failed for \(attachment.name, privacy: .public); extracting from raw source")
+                    if messageSourceCache == nil {
+                        messageSourceCache = try MailBridge.messageSource(messageID: message.id)
+                    }
+                    guard let source = messageSourceCache,
+                          let data = MIMEExtractor.attachmentData(named: attachment.name, inSource: source) else {
+                        throw MailBridgeError.scriptError("Could not extract \(attachment.name) from the raw message.")
+                    }
+                    try data.write(to: stagedFile)
+                }
                 guard FileManager.default.fileExists(atPath: stagedFile.path) else {
                     throw MailBridgeError.scriptError("Mail did not write \(attachment.name).")
                 }
@@ -117,11 +132,21 @@ enum AttachmentUnloader {
                 let finalURL = uniqueURL(in: destination, fileName: finalName)
                 try FileManager.default.moveItem(at: stagedFile, to: finalURL)
 
-                try MailBridge.deleteAttachment(messageID: message.id, attachmentID: attachment.id)
+                // The file is safe now — a removal failure downgrades the row
+                // instead of losing the save.
+                var removed = true
+                do {
+                    try MailBridge.deleteAttachment(messageID: message.id, attachmentID: attachment.id)
+                } catch {
+                    removed = false
+                    let reason = "\(attachment.name) was saved, but could not be removed from the email: \(error.localizedDescription)"
+                    logger.error("\(reason, privacy: .public)")
+                    failureReasons.append(reason)
+                }
 
                 let published = await publishedURL(for: finalURL)
                 records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText,
-                                                status: .saved(finalURL, publishedURL: published)))
+                                                status: .saved(finalURL, publishedURL: published, removed: removed)))
                 savedCount += 1
             } catch {
                 let reason = "\(attachment.name): \(error.localizedDescription)"
@@ -136,7 +161,13 @@ enum AttachmentUnloader {
         if savedCount > 0 {
             let original = (try? MailBridge.messageContent(messageID: message.id)) ?? ""
             let table = summaryTable(for: records)
-            try? MailBridge.setMessageContent(messageID: message.id, content: table + "<br>" + original)
+            do {
+                try MailBridge.setMessageContent(messageID: message.id, content: table + "<br>" + original)
+            } catch {
+                let reason = "Could not add the summary table to the email: \(error.localizedDescription)"
+                logger.error("\(reason, privacy: .public)")
+                failureReasons.append(reason)
+            }
         }
 
         return ProcessResult(subject: message.subject, savedCount: savedCount,
@@ -201,8 +232,8 @@ enum AttachmentUnloader {
             let statusText: String
             let linksText: String
             switch record.status {
-            case .saved(let fileURL, let publishedURL):
-                statusText = "✓ Saved & removed"
+            case .saved(let fileURL, let publishedURL, let removed):
+                statusText = removed ? "✓ Saved & removed" : "✓ Saved — attachment left in email"
                 var links = "<a href='\(fileURL.absoluteString)'>Open on this Mac</a>"
                 if let publishedURL {
                     links += " &nbsp;|&nbsp; <a href='\(publishedURL.absoluteString)'>Download (any device)</a>"

--- a/Unload Attachments/AttachmentUnloader.swift
+++ b/Unload Attachments/AttachmentUnloader.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 struct AttachmentRecord {
     enum Status {
@@ -16,10 +17,13 @@ struct ProcessResult {
     let subject: String
     let savedCount: Int
     let failedCount: Int
+    let failureReasons: [String]
 }
 
 @MainActor
 enum AttachmentUnloader {
+
+    private static let logger = Logger(subsystem: "com.jerfiss.Unload-Attachments", category: "unloader")
 
     /// File types that are saved out of the message and removed from it.
     static let officeExtensions: Set<String> = ["xls", "xlsx", "doc", "docx", "ppt", "pptx", "pdf"]
@@ -84,6 +88,7 @@ enum AttachmentUnloader {
         var records: [AttachmentRecord] = []
         var savedCount = 0
         var failedCount = 0
+        var failureReasons: [String] = []
 
         for attachment in message.attachments {
             let sizeText = formatter.string(fromByteCount: Int64(attachment.fileSize))
@@ -102,8 +107,8 @@ enum AttachmentUnloader {
                 try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
                 defer { try? FileManager.default.removeItem(at: staging) }
 
-                try MailBridge.saveAttachment(messageID: message.id, attachmentID: attachment.id, toFolder: staging)
                 let stagedFile = staging.appendingPathComponent(attachment.name)
+                try MailBridge.saveAttachment(messageID: message.id, attachmentID: attachment.id, toFile: stagedFile)
                 guard FileManager.default.fileExists(atPath: stagedFile.path) else {
                     throw MailBridgeError.scriptError("Mail did not write \(attachment.name).")
                 }
@@ -119,6 +124,9 @@ enum AttachmentUnloader {
                                                 status: .saved(finalURL, publishedURL: published)))
                 savedCount += 1
             } catch {
+                let reason = "\(attachment.name): \(error.localizedDescription)"
+                logger.error("Failed to unload \(reason, privacy: .public)")
+                failureReasons.append(reason)
                 records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText,
                                                 status: .failed(error.localizedDescription)))
                 failedCount += 1
@@ -131,7 +139,8 @@ enum AttachmentUnloader {
             try? MailBridge.setMessageContent(messageID: message.id, content: table + "<br>" + original)
         }
 
-        return ProcessResult(subject: message.subject, savedCount: savedCount, failedCount: failedCount)
+        return ProcessResult(subject: message.subject, savedCount: savedCount,
+                             failedCount: failedCount, failureReasons: failureReasons)
     }
 
     // MARK: - iCloud link publishing

--- a/Unload Attachments/AttachmentUnloader.swift
+++ b/Unload Attachments/AttachmentUnloader.swift
@@ -1,22 +1,11 @@
 import Foundation
 import OSLog
 
-struct AttachmentRecord {
-    enum Status {
-        case saved(URL, publishedURL: URL?, removed: Bool)
-        case failed(String)
-        case leftInPlace
-    }
-
-    let name: String
-    let sizeText: String
-    let status: Status
-}
-
 struct ProcessResult {
     let subject: String
     let savedCount: Int
     let failedCount: Int
+    let savedFiles: [URL]
     let failureReasons: [String]
 }
 
@@ -25,7 +14,7 @@ enum AttachmentUnloader {
 
     private static let logger = Logger(subsystem: "com.jerfiss.Unload-Attachments", category: "unloader")
 
-    /// File types that are saved out of the message and removed from it.
+    /// File types that are saved out of incoming messages.
     static let officeExtensions: Set<String> = ["xls", "xlsx", "doc", "docx", "ppt", "pptx", "pdf"]
 
     private static let typeFolderNames: [String: String] = [
@@ -47,7 +36,8 @@ enum AttachmentUnloader {
     }
 
     /// The parent folder that holds all unloaded attachments. Prefers the
-    /// user-chosen override, then iCloud Drive, then local Documents.
+    /// user-chosen override, then iCloud Drive, then local Documents (which
+    /// is itself iCloud-synced when Desktop & Documents sync is on).
     static var parentFolder: URL {
         if let override = AppSettings.parentFolderOverride { return override }
         if let icloud = iCloudDriveDocumentsURL {
@@ -81,23 +71,16 @@ enum AttachmentUnloader {
     // MARK: - Processing
 
     /// Saves each Office/PDF attachment of the message to the destination
-    /// folder, removes it from the message, and prepends an HTML summary
-    /// table with links to the saved files.
+    /// folder. The message itself is left untouched: modern Mail rejects all
+    /// scripted modifications of received messages.
     static func process(_ message: InboxMessage) async -> ProcessResult {
-        let formatter = ByteCountFormatter()
-        var records: [AttachmentRecord] = []
         var savedCount = 0
         var failedCount = 0
+        var savedFiles: [URL] = []
         var failureReasons: [String] = []
         var messageSourceCache: String?
 
-        for attachment in message.attachments {
-            let sizeText = formatter.string(fromByteCount: Int64(attachment.fileSize))
-            guard officeExtensions.contains(attachment.fileExtension) else {
-                records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText, status: .leftInPlace))
-                continue
-            }
-
+        for attachment in message.attachments where officeExtensions.contains(attachment.fileExtension) {
             do {
                 let destination = try destinationFolder(for: attachment.fileExtension, receivedAt: message.dateReceived)
 
@@ -114,7 +97,6 @@ enum AttachmentUnloader {
                 } catch {
                     // Mail's scripted save is broken on modern macOS (-10000);
                     // extract the attachment from the raw message source instead.
-                    logger.notice("Scripted save failed for \(attachment.name, privacy: .public); extracting from raw source")
                     if messageSourceCache == nil {
                         messageSourceCache = try MailBridge.messageSource(messageID: message.id)
                     }
@@ -132,65 +114,20 @@ enum AttachmentUnloader {
                 let finalURL = uniqueURL(in: destination, fileName: finalName)
                 try FileManager.default.moveItem(at: stagedFile, to: finalURL)
 
-                // The file is safe now — a removal failure downgrades the row
-                // instead of losing the save.
-                var removed = true
-                do {
-                    try MailBridge.deleteAttachment(messageID: message.id, attachmentID: attachment.id)
-                } catch {
-                    removed = false
-                    let reason = "\(attachment.name) was saved, but could not be removed from the email: \(error.localizedDescription)"
-                    logger.error("\(reason, privacy: .public)")
-                    failureReasons.append(reason)
-                }
-
-                let published = await publishedURL(for: finalURL)
-                records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText,
-                                                status: .saved(finalURL, publishedURL: published, removed: removed)))
+                logger.notice("Saved \(finalURL.path, privacy: .public)")
+                savedFiles.append(finalURL)
                 savedCount += 1
             } catch {
                 let reason = "\(attachment.name): \(error.localizedDescription)"
                 logger.error("Failed to unload \(reason, privacy: .public)")
                 failureReasons.append(reason)
-                records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText,
-                                                status: .failed(error.localizedDescription)))
                 failedCount += 1
             }
         }
 
-        if savedCount > 0 {
-            let original = (try? MailBridge.messageContent(messageID: message.id)) ?? ""
-            let table = summaryTable(for: records)
-            do {
-                try MailBridge.setMessageContent(messageID: message.id, content: table + "<br>" + original)
-            } catch {
-                let reason = "Could not add the summary table to the email: \(error.localizedDescription)"
-                logger.error("\(reason, privacy: .public)")
-                failureReasons.append(reason)
-            }
-        }
-
         return ProcessResult(subject: message.subject, savedCount: savedCount,
-                             failedCount: failedCount, failureReasons: failureReasons)
-    }
-
-    // MARK: - iCloud link publishing
-
-    /// Waits for the file's iCloud upload and returns an emailable https
-    /// download URL, or nil when publishing isn't possible (local folder,
-    /// no iCloud, timeout).
-    static func publishedURL(for fileURL: URL, timeout: TimeInterval = 45) async -> URL? {
-        let fileManager = FileManager.default
-        guard fileManager.isUbiquitousItem(at: fileURL) else { return nil }
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            do {
-                return try fileManager.url(forPublishingUbiquitousItemAt: fileURL, expiration: nil)
-            } catch {
-                try? await Task.sleep(for: .seconds(3))
-            }
-        }
-        return nil
+                             failedCount: failedCount, savedFiles: savedFiles,
+                             failureReasons: failureReasons)
     }
 
     // MARK: - Naming
@@ -219,51 +156,5 @@ enum AttachmentUnloader {
             counter += 1
         }
         return candidate
-    }
-
-    // MARK: - HTML summary
-
-    private static func summaryTable(for records: [AttachmentRecord]) -> String {
-        let cellStyle = "padding:4px 8px; border:1px solid #ccc;"
-        let headerStyle = "background:#f0f0f0; \(cellStyle) text-align:left;"
-
-        var rows = ""
-        for record in records {
-            let statusText: String
-            let linksText: String
-            switch record.status {
-            case .saved(let fileURL, let publishedURL, let removed):
-                statusText = removed ? "✓ Saved & removed" : "✓ Saved — attachment left in email"
-                var links = "<a href='\(fileURL.absoluteString)'>Open on this Mac</a>"
-                if let publishedURL {
-                    links += " &nbsp;|&nbsp; <a href='\(publishedURL.absoluteString)'>Download (any device)</a>"
-                }
-                links += "<br><small>\(locationText(for: fileURL))</small>"
-                linksText = links
-            case .failed(let reason):
-                statusText = "⚠ Error — not removed (\(reason))"
-                linksText = ""
-            case .leftInPlace:
-                statusText = "— left in place"
-                linksText = ""
-            }
-            rows += "<tr><td style='\(cellStyle)'>\(record.name)</td>"
-                + "<td style='\(cellStyle)'>\(record.sizeText)</td>"
-                + "<td style='\(cellStyle)'>\(statusText)</td>"
-                + "<td style='\(cellStyle)'>\(linksText)</td></tr>"
-        }
-
-        return "<table style='border-collapse:collapse; font-family:sans-serif; font-size:12px; margin-bottom:12px;'>"
-            + "<tr><th style='\(headerStyle)'>Attachment</th><th style='\(headerStyle)'>Size</th>"
-            + "<th style='\(headerStyle)'>Status</th><th style='\(headerStyle)'>Links</th></tr>"
-            + rows + "</table>"
-    }
-
-    private static func locationText(for fileURL: URL) -> String {
-        let components = fileURL.pathComponents
-        if let index = components.firstIndex(of: "com~apple~CloudDocs") {
-            return (["iCloud Drive"] + components[(index + 1)...]).joined(separator: " ▸ ")
-        }
-        return fileURL.path
     }
 }

--- a/Unload Attachments/AttachmentUnloader.swift
+++ b/Unload Attachments/AttachmentUnloader.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+struct AttachmentRecord {
+    enum Status {
+        case saved(URL, publishedURL: URL?)
+        case failed(String)
+        case leftInPlace
+    }
+
+    let name: String
+    let sizeText: String
+    let status: Status
+}
+
+struct ProcessResult {
+    let subject: String
+    let savedCount: Int
+    let failedCount: Int
+}
+
+@MainActor
+enum AttachmentUnloader {
+
+    /// File types that are saved out of the message and removed from it.
+    static let officeExtensions: Set<String> = ["xls", "xlsx", "doc", "docx", "ppt", "pptx", "pdf"]
+
+    private static let typeFolderNames: [String: String] = [
+        "pdf": "pdf",
+        "doc": "word", "docx": "word",
+        "xls": "excel", "xlsx": "excel",
+        "ppt": "powerpoint", "pptx": "powerpoint",
+    ]
+
+    // MARK: - Folders
+
+    /// iCloud Drive ▸ Documents, or nil when iCloud Drive is unavailable.
+    static var iCloudDriveDocumentsURL: URL? {
+        guard FileManager.default.ubiquityIdentityToken != nil else { return nil }
+        let root = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Mobile Documents/com~apple~CloudDocs", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: root.path) else { return nil }
+        return root.appendingPathComponent("Documents", isDirectory: true)
+    }
+
+    /// The parent folder that holds all unloaded attachments. Prefers the
+    /// user-chosen override, then iCloud Drive, then local Documents.
+    static var parentFolder: URL {
+        if let override = AppSettings.parentFolderOverride { return override }
+        if let icloud = iCloudDriveDocumentsURL {
+            return icloud.appendingPathComponent("unloader-files", isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/unloader-files", isDirectory: true)
+    }
+
+    /// First-launch setup: make sure the parent folder exists.
+    @discardableResult
+    static func ensureFoldersExist() throws -> URL {
+        try FileManager.default.createDirectory(at: parentFolder, withIntermediateDirectories: true)
+        return parentFolder
+    }
+
+    /// Subfolder for one file according to the active organization scheme.
+    static func destinationFolder(for fileExtension: String, receivedAt date: Date) throws -> URL {
+        let subfolder: String
+        switch AppSettings.folderScheme {
+        case .byYear:
+            subfolder = String(Calendar.current.component(.year, from: date))
+        case .byType:
+            subfolder = typeFolderNames[fileExtension] ?? fileExtension
+        }
+        let folder = parentFolder.appendingPathComponent(subfolder, isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        return folder
+    }
+
+    // MARK: - Processing
+
+    /// Saves each Office/PDF attachment of the message to the destination
+    /// folder, removes it from the message, and prepends an HTML summary
+    /// table with links to the saved files.
+    static func process(_ message: InboxMessage) async -> ProcessResult {
+        let formatter = ByteCountFormatter()
+        var records: [AttachmentRecord] = []
+        var savedCount = 0
+        var failedCount = 0
+
+        for attachment in message.attachments {
+            let sizeText = formatter.string(fromByteCount: Int64(attachment.fileSize))
+            guard officeExtensions.contains(attachment.fileExtension) else {
+                records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText, status: .leftInPlace))
+                continue
+            }
+
+            do {
+                let destination = try destinationFolder(for: attachment.fileExtension, receivedAt: message.dateReceived)
+
+                // Mail saves with the attachment's original name, so stage in
+                // a private temp folder to avoid clobbering earlier saves.
+                let staging = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("unloader-\(UUID().uuidString)", isDirectory: true)
+                try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+                defer { try? FileManager.default.removeItem(at: staging) }
+
+                try MailBridge.saveAttachment(messageID: message.id, attachmentID: attachment.id, toFolder: staging)
+                let stagedFile = staging.appendingPathComponent(attachment.name)
+                guard FileManager.default.fileExists(atPath: stagedFile.path) else {
+                    throw MailBridgeError.scriptError("Mail did not write \(attachment.name).")
+                }
+
+                let finalName = timestamp(for: message.dateReceived) + "_" + cleanedFileName(attachment.name)
+                let finalURL = uniqueURL(in: destination, fileName: finalName)
+                try FileManager.default.moveItem(at: stagedFile, to: finalURL)
+
+                try MailBridge.deleteAttachment(messageID: message.id, attachmentID: attachment.id)
+
+                let published = await publishedURL(for: finalURL)
+                records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText,
+                                                status: .saved(finalURL, publishedURL: published)))
+                savedCount += 1
+            } catch {
+                records.append(AttachmentRecord(name: attachment.name, sizeText: sizeText,
+                                                status: .failed(error.localizedDescription)))
+                failedCount += 1
+            }
+        }
+
+        if savedCount > 0 {
+            let original = (try? MailBridge.messageContent(messageID: message.id)) ?? ""
+            let table = summaryTable(for: records)
+            try? MailBridge.setMessageContent(messageID: message.id, content: table + "<br>" + original)
+        }
+
+        return ProcessResult(subject: message.subject, savedCount: savedCount, failedCount: failedCount)
+    }
+
+    // MARK: - iCloud link publishing
+
+    /// Waits for the file's iCloud upload and returns an emailable https
+    /// download URL, or nil when publishing isn't possible (local folder,
+    /// no iCloud, timeout).
+    static func publishedURL(for fileURL: URL, timeout: TimeInterval = 45) async -> URL? {
+        let fileManager = FileManager.default
+        guard fileManager.isUbiquitousItem(at: fileURL) else { return nil }
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            do {
+                return try fileManager.url(forPublishingUbiquitousItemAt: fileURL, expiration: nil)
+            } catch {
+                try? await Task.sleep(for: .seconds(3))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Naming
+
+    /// Removes the characters the original AppleScript disallowed, including spaces.
+    static func cleanedFileName(_ name: String) -> String {
+        let disallowed = Set(":;,'/|!@#$%^&*()- ")
+        let cleaned = String(name.filter { !disallowed.contains($0) })
+        return cleaned.isEmpty ? "attachment" : cleaned
+    }
+
+    private static func timestamp(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HHmmss"
+        return formatter.string(from: date)
+    }
+
+    private static func uniqueURL(in folder: URL, fileName: String) -> URL {
+        var candidate = folder.appendingPathComponent(fileName)
+        let base = (fileName as NSString).deletingPathExtension
+        let ext = (fileName as NSString).pathExtension
+        var counter = 1
+        while FileManager.default.fileExists(atPath: candidate.path) {
+            let next = ext.isEmpty ? "\(base)-\(counter)" : "\(base)-\(counter).\(ext)"
+            candidate = folder.appendingPathComponent(next)
+            counter += 1
+        }
+        return candidate
+    }
+
+    // MARK: - HTML summary
+
+    private static func summaryTable(for records: [AttachmentRecord]) -> String {
+        let cellStyle = "padding:4px 8px; border:1px solid #ccc;"
+        let headerStyle = "background:#f0f0f0; \(cellStyle) text-align:left;"
+
+        var rows = ""
+        for record in records {
+            let statusText: String
+            let linksText: String
+            switch record.status {
+            case .saved(let fileURL, let publishedURL):
+                statusText = "✓ Saved & removed"
+                var links = "<a href='\(fileURL.absoluteString)'>Open on this Mac</a>"
+                if let publishedURL {
+                    links += " &nbsp;|&nbsp; <a href='\(publishedURL.absoluteString)'>Download (any device)</a>"
+                }
+                links += "<br><small>\(locationText(for: fileURL))</small>"
+                linksText = links
+            case .failed(let reason):
+                statusText = "⚠ Error — not removed (\(reason))"
+                linksText = ""
+            case .leftInPlace:
+                statusText = "— left in place"
+                linksText = ""
+            }
+            rows += "<tr><td style='\(cellStyle)'>\(record.name)</td>"
+                + "<td style='\(cellStyle)'>\(record.sizeText)</td>"
+                + "<td style='\(cellStyle)'>\(statusText)</td>"
+                + "<td style='\(cellStyle)'>\(linksText)</td></tr>"
+        }
+
+        return "<table style='border-collapse:collapse; font-family:sans-serif; font-size:12px; margin-bottom:12px;'>"
+            + "<tr><th style='\(headerStyle)'>Attachment</th><th style='\(headerStyle)'>Size</th>"
+            + "<th style='\(headerStyle)'>Status</th><th style='\(headerStyle)'>Links</th></tr>"
+            + rows + "</table>"
+    }
+
+    private static func locationText(for fileURL: URL) -> String {
+        let components = fileURL.pathComponents
+        if let index = components.firstIndex(of: "com~apple~CloudDocs") {
+            return (["iCloud Drive"] + components[(index + 1)...]).joined(separator: " ▸ ")
+        }
+        return fileURL.path
+    }
+}

--- a/Unload Attachments/AttachmentUnloader.swift
+++ b/Unload Attachments/AttachmentUnloader.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-struct ProcessResult {
+nonisolated struct ProcessResult: Sendable {
     let subject: String
     let savedCount: Int
     let failedCount: Int
@@ -9,8 +9,9 @@ struct ProcessResult {
     let failureReasons: [String]
 }
 
-@MainActor
-enum AttachmentUnloader {
+/// Pure helpers for extracting and filing attachments. Runs off the main
+/// thread (called from MailWorker); must not touch main-actor state.
+nonisolated enum AttachmentUnloader {
 
     private static let logger = Logger(subsystem: "com.jerfiss.Unload-Attachments", category: "unloader")
 
@@ -70,49 +71,24 @@ enum AttachmentUnloader {
 
     // MARK: - Processing
 
-    /// Saves each Office/PDF attachment of the message to the destination
-    /// folder. The message itself is left untouched: modern Mail rejects all
-    /// scripted modifications of received messages.
-    static func process(_ message: InboxMessage) async -> ProcessResult {
+    /// Extracts each Office/PDF attachment from the raw message source and
+    /// writes it to the destination folder.
+    static func process(_ message: InboxMessage, source: String) -> ProcessResult {
         var savedCount = 0
         var failedCount = 0
         var savedFiles: [URL] = []
         var failureReasons: [String] = []
-        var messageSourceCache: String?
 
         for attachment in message.attachments where officeExtensions.contains(attachment.fileExtension) {
             do {
                 let destination = try destinationFolder(for: attachment.fileExtension, receivedAt: message.dateReceived)
-
-                // Mail saves with the attachment's original name, so stage in
-                // a private temp folder to avoid clobbering earlier saves.
-                let staging = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("unloader-\(UUID().uuidString)", isDirectory: true)
-                try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
-                defer { try? FileManager.default.removeItem(at: staging) }
-
-                let stagedFile = staging.appendingPathComponent(attachment.name)
-                do {
-                    try MailBridge.saveAttachment(messageID: message.id, attachmentID: attachment.id, toFile: stagedFile)
-                } catch {
-                    // Mail's scripted save is broken on modern macOS (-10000);
-                    // extract the attachment from the raw message source instead.
-                    if messageSourceCache == nil {
-                        messageSourceCache = try MailBridge.messageSource(messageID: message.id)
-                    }
-                    guard let source = messageSourceCache,
-                          let data = MIMEExtractor.attachmentData(named: attachment.name, inSource: source) else {
-                        throw MailBridgeError.scriptError("Could not extract \(attachment.name) from the raw message.")
-                    }
-                    try data.write(to: stagedFile)
-                }
-                guard FileManager.default.fileExists(atPath: stagedFile.path) else {
-                    throw MailBridgeError.scriptError("Mail did not write \(attachment.name).")
+                guard let data = MIMEExtractor.attachmentData(named: attachment.name, inSource: source) else {
+                    throw MailBridgeError.scriptError("Could not extract \(attachment.name) from the raw message.")
                 }
 
                 let finalName = timestamp(for: message.dateReceived) + "_" + cleanedFileName(attachment.name)
                 let finalURL = uniqueURL(in: destination, fileName: finalName)
-                try FileManager.default.moveItem(at: stagedFile, to: finalURL)
+                try data.write(to: finalURL, options: [.withoutOverwriting])
 
                 logger.notice("Saved \(finalURL.path, privacy: .public)")
                 savedFiles.append(finalURL)

--- a/Unload Attachments/MIMEExtractor.swift
+++ b/Unload Attachments/MIMEExtractor.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// Extracts attachment data from a raw RFC 822 message source. This is the
-/// fallback for Mail's scripted `save` command, which fails with
-/// "AppleEvent handler failed" (-10000) on modern macOS versions.
-enum MIMEExtractor {
+/// Extracts attachment data from a raw RFC 822 message source. Mail's
+/// scripted `save` command fails with "AppleEvent handler failed" (-10000)
+/// on modern macOS versions, so this is how attachments are saved.
+nonisolated enum MIMEExtractor {
 
     /// Finds the MIME part whose filename matches and returns its decoded data.
     static func attachmentData(named fileName: String, inSource source: String) -> Data? {

--- a/Unload Attachments/MIMEExtractor.swift
+++ b/Unload Attachments/MIMEExtractor.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Extracts attachment data from a raw RFC 822 message source. This is the
+/// fallback for Mail's scripted `save` command, which fails with
+/// "AppleEvent handler failed" (-10000) on modern macOS versions.
+enum MIMEExtractor {
+
+    /// Finds the MIME part whose filename matches and returns its decoded data.
+    static func attachmentData(named fileName: String, inSource source: String) -> Data? {
+        let lines = source
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+
+        // Find the header line that names this attachment
+        // (Content-Disposition: ... filename="X" or Content-Type: ... name="X").
+        guard let nameLineIndex = lines.firstIndex(where: { line in
+            let lowered = line.lowercased()
+            return (lowered.contains("filename") || lowered.contains("name=")) && line.contains(fileName)
+        }) else { return nil }
+
+        // Walk back to this part's boundary line, then forward through its
+        // headers to the blank line, noting the transfer encoding.
+        var partStart = nameLineIndex
+        while partStart > 0 && !lines[partStart].hasPrefix("--") { partStart -= 1 }
+
+        var encoding = "base64"
+        var index = partStart
+        while index < lines.count && !lines[index].isEmpty {
+            let lowered = lines[index].lowercased()
+            if lowered.hasPrefix("content-transfer-encoding:") {
+                encoding = lowered
+                    .replacingOccurrences(of: "content-transfer-encoding:", with: "")
+                    .trimmingCharacters(in: .whitespaces)
+            }
+            index += 1
+        }
+        guard index < lines.count else { return nil }
+
+        // Collect the body until the next boundary. Base64's alphabet never
+        // starts a line with "--", so this cleanly stops at the boundary.
+        var bodyLines: [String] = []
+        index += 1
+        while index < lines.count && !lines[index].hasPrefix("--") {
+            bodyLines.append(lines[index])
+            index += 1
+        }
+
+        switch encoding {
+        case "base64":
+            return Data(base64Encoded: bodyLines.joined(), options: .ignoreUnknownCharacters)
+        case "quoted-printable":
+            return decodeQuotedPrintable(bodyLines.joined(separator: "\n"))
+        case "7bit", "8bit", "binary", "":
+            return bodyLines.joined(separator: "\n").data(using: .utf8)
+        default:
+            return nil
+        }
+    }
+
+    private static func decodeQuotedPrintable(_ text: String) -> Data? {
+        let bytes = Array(text.utf8)
+        var result = Data()
+        var i = 0
+        while i < bytes.count {
+            if bytes[i] == UInt8(ascii: "=") {
+                if i + 2 < bytes.count, let high = hexValue(bytes[i + 1]), let low = hexValue(bytes[i + 2]) {
+                    result.append(high << 4 | low)
+                    i += 3
+                } else if i + 1 < bytes.count, bytes[i + 1] == UInt8(ascii: "\n") {
+                    i += 2 // soft line break
+                } else {
+                    i += 1
+                }
+            } else if bytes[i] == UInt8(ascii: "\n") {
+                result.append(contentsOf: [0x0D, 0x0A])
+                i += 1
+            } else {
+                result.append(bytes[i])
+                i += 1
+            }
+        }
+        return result
+    }
+
+    private static func hexValue(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case UInt8(ascii: "0")...UInt8(ascii: "9"): return byte - UInt8(ascii: "0")
+        case UInt8(ascii: "A")...UInt8(ascii: "F"): return byte - UInt8(ascii: "A") + 10
+        case UInt8(ascii: "a")...UInt8(ascii: "f"): return byte - UInt8(ascii: "a") + 10
+        default: return nil
+        }
+    }
+}

--- a/Unload Attachments/MailBridge.swift
+++ b/Unload Attachments/MailBridge.swift
@@ -129,15 +129,6 @@ enum MailBridge {
         }
     }
 
-    static func deleteAttachment(messageID: Int, attachmentID: String) throws {
-        try run("""
-        tell application "Mail"
-            set theMessage to first message of inbox whose id is \(messageID)
-            delete (first mail attachment of theMessage whose id is \(quoted(attachmentID)))
-        end tell
-        """)
-    }
-
     static func messageSource(messageID: Int) throws -> String {
         let result = try run("""
         tell application "Mail"
@@ -146,25 +137,6 @@ enum MailBridge {
         end tell
         """)
         return result.stringValue ?? ""
-    }
-
-    static func messageContent(messageID: Int) throws -> String {
-        let result = try run("""
-        tell application "Mail"
-            set theMessage to first message of inbox whose id is \(messageID)
-            return content of theMessage
-        end tell
-        """)
-        return result.stringValue ?? ""
-    }
-
-    static func setMessageContent(messageID: Int, content: String) throws {
-        try run("""
-        tell application "Mail"
-            set theMessage to first message of inbox whose id is \(messageID)
-            set content of theMessage to \(quoted(content))
-        end tell
-        """)
     }
 
     // MARK: - Helpers

--- a/Unload Attachments/MailBridge.swift
+++ b/Unload Attachments/MailBridge.swift
@@ -4,23 +4,24 @@ import ScriptingBridge
 // Minimal typed views of Mail's scripting interface. ScriptingBridge resolves
 // these members dynamically from Mail's scripting definition at runtime; the
 // protocols only exist to satisfy the compiler.
-@objc protocol MailApplicationSB {
+@objc nonisolated protocol MailApplicationSB {
     @objc optional var inbox: SBObject { get }
 }
 
-@objc protocol MailMailboxSB {
+@objc nonisolated protocol MailMailboxSB {
     @objc optional func messages() -> SBElementArray
 }
 
-@objc protocol MailMessageSB {
+@objc nonisolated protocol MailMessageSB {
     @objc optional var id: Int { get }
     @objc optional var messageId: String { get }
     @objc optional var subject: String { get }
     @objc optional var dateReceived: Date { get }
+    @objc optional var source: String { get }
     @objc optional func mailAttachments() -> SBElementArray
 }
 
-@objc protocol MailAttachmentSB {
+@objc nonisolated protocol MailAttachmentSB {
     @objc optional var id: String { get }
     @objc optional var name: String { get }
     @objc optional var fileSize: Int { get }
@@ -29,7 +30,7 @@ import ScriptingBridge
 extension SBApplication: MailApplicationSB {}
 extension SBObject: MailMailboxSB, MailMessageSB, MailAttachmentSB {}
 
-struct InboxAttachment {
+nonisolated struct InboxAttachment: Sendable {
     let id: String
     let name: String
     let fileSize: Int
@@ -39,7 +40,7 @@ struct InboxAttachment {
     }
 }
 
-struct InboxMessage {
+nonisolated struct InboxMessage: Sendable {
     let id: Int
     let messageID: String
     let subject: String
@@ -47,7 +48,7 @@ struct InboxMessage {
     let attachments: [InboxAttachment]
 }
 
-enum MailBridgeError: LocalizedError {
+nonisolated enum MailBridgeError: LocalizedError {
     case scriptError(String)
 
     var errorDescription: String? {
@@ -57,21 +58,20 @@ enum MailBridgeError: LocalizedError {
     }
 }
 
-@MainActor
-enum MailBridge {
+/// Owns all ScriptingBridge access to Mail on its own executor, so Apple-event
+/// round trips (which can take seconds on a large inbox) never block the main
+/// thread and the menu bar UI.
+actor MailWorker {
 
-    static var isMailRunning: Bool {
+    static let shared = MailWorker()
+
+    func isMailRunning() -> Bool {
         SBApplication(bundleIdentifier: "com.apple.mail")?.isRunning ?? false
     }
 
-    // MARK: - Reading (ScriptingBridge)
-
     /// Snapshots inbox messages received after the given date.
-    static func inboxMessages(receivedAfter date: Date) -> [InboxMessage] {
-        guard let app = SBApplication(bundleIdentifier: "com.apple.mail"), app.isRunning,
-              let inbox = (app as MailApplicationSB).inbox,
-              let messages = (inbox as MailMailboxSB).messages?()
-        else { return [] }
+    func newMessages(receivedAfter date: Date) -> [InboxMessage] {
+        guard let messages = inboxMessagesArray() else { return [] }
 
         let recent = messages.filtered(using: NSPredicate(format: "dateReceived > %@", date as NSDate))
 
@@ -100,69 +100,32 @@ enum MailBridge {
         return result.sorted { $0.dateReceived < $1.dateReceived }
     }
 
-    // MARK: - Mutations (parameterized AppleScript)
-    // ScriptingBridge is unreliable for Mail's save/delete/set-content
-    // commands, so these go through small NSAppleScript snippets instead.
-
-    static func saveAttachment(messageID: Int, attachmentID: String, toFile file: URL) throws {
-        let lookup = """
-            set theMessage to first message of inbox whose id is \(messageID)
-            set theAttachment to first mail attachment of theMessage whose id is \(quoted(attachmentID))
-        """
-        do {
-            // Modern Mail expects the full destination file path.
-            try run("""
-            tell application "Mail"
-            \(lookup)
-                save theAttachment in (POSIX file \(quoted(file.path)))
-            end tell
-            """)
-        } catch {
-            // Older Mail versions instead save into a folder, keeping the
-            // attachment's original name.
-            try run("""
-            tell application "Mail"
-            \(lookup)
-                save theAttachment in ((POSIX file \(quoted(file.deletingLastPathComponent().path + "/"))) as alias)
-            end tell
-            """)
+    /// Saves the message's Office/PDF attachments and reports the outcome.
+    /// The message itself is never modified: modern Mail rejects all scripted
+    /// modifications of received messages, so attachments are extracted from
+    /// the raw message source instead.
+    func unload(_ message: InboxMessage) -> ProcessResult {
+        guard let source = messageSource(messageID: message.id), !source.isEmpty else {
+            let reason = "Could not read the raw source of “\(message.subject)” from Mail."
+            return ProcessResult(subject: message.subject, savedCount: 0, failedCount: 1,
+                                 savedFiles: [], failureReasons: [reason])
         }
+        return AttachmentUnloader.process(message, source: source)
     }
 
-    static func messageSource(messageID: Int) throws -> String {
-        let result = try run("""
-        tell application "Mail"
-            set theMessage to first message of inbox whose id is \(messageID)
-            return source of theMessage
-        end tell
-        """)
-        return result.stringValue ?? ""
+    // MARK: - Private
+
+    private func inboxMessagesArray() -> SBElementArray? {
+        guard let app = SBApplication(bundleIdentifier: "com.apple.mail"), app.isRunning,
+              let inbox = (app as MailApplicationSB).inbox
+        else { return nil }
+        return (inbox as MailMailboxSB).messages?()
     }
 
-    // MARK: - Helpers
-
-    /// Escapes a Swift string into an AppleScript string literal.
-    private static func quoted(_ string: String) -> String {
-        "\"" + string
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "\r\n", with: "\\n")
-            .replacingOccurrences(of: "\n", with: "\\n")
-            .replacingOccurrences(of: "\r", with: "\\r")
-        + "\""
-    }
-
-    @discardableResult
-    private static func run(_ source: String) throws -> NSAppleEventDescriptor {
-        guard let script = NSAppleScript(source: source) else {
-            throw MailBridgeError.scriptError("Could not compile Mail script.")
-        }
-        var errorInfo: NSDictionary?
-        let result = script.executeAndReturnError(&errorInfo)
-        if let errorInfo {
-            let message = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown Mail scripting error."
-            throw MailBridgeError.scriptError(message)
-        }
-        return result
+    private func messageSource(messageID: Int) -> String? {
+        guard let messages = inboxMessagesArray() else { return nil }
+        let matches = messages.filtered(using: NSPredicate(format: "id == %d", messageID))
+        guard let message = matches.first as? SBObject else { return nil }
+        return (message as MailMessageSB).source
     }
 }

--- a/Unload Attachments/MailBridge.swift
+++ b/Unload Attachments/MailBridge.swift
@@ -138,6 +138,16 @@ enum MailBridge {
         """)
     }
 
+    static func messageSource(messageID: Int) throws -> String {
+        let result = try run("""
+        tell application "Mail"
+            set theMessage to first message of inbox whose id is \(messageID)
+            return source of theMessage
+        end tell
+        """)
+        return result.stringValue ?? ""
+    }
+
     static func messageContent(messageID: Int) throws -> String {
         let result = try run("""
         tell application "Mail"

--- a/Unload Attachments/MailBridge.swift
+++ b/Unload Attachments/MailBridge.swift
@@ -18,6 +18,9 @@ import ScriptingBridge
     @objc optional var subject: String { get }
     @objc optional var dateReceived: Date { get }
     @objc optional var source: String { get }
+    @objc optional var flaggedStatus: Bool { get }
+    @objc optional func setFlaggedStatus(_ flagged: Bool)
+    @objc optional func setFlagIndex(_ index: Int)
     @objc optional func mailAttachments() -> SBElementArray
 }
 
@@ -113,7 +116,25 @@ actor MailWorker {
         return AttachmentUnloader.process(message, source: source)
     }
 
+    /// Flags the message (green) to show its attachments were unloaded.
+    /// Flag status is message metadata, which Mail still allows scripts to
+    /// change — unlike message content. Returns false if Mail rejected it.
+    func flagMessage(messageID: Int) -> Bool {
+        guard let message = inboxMessage(withID: messageID) else { return false }
+        let m = message as MailMessageSB
+        m.setFlaggedStatus?(true)
+        m.setFlagIndex?(3) // green
+        // ScriptingBridge setters fail silently, so read back to verify.
+        return m.flaggedStatus ?? false
+    }
+
     // MARK: - Private
+
+    private func inboxMessage(withID messageID: Int) -> SBObject? {
+        guard let messages = inboxMessagesArray() else { return nil }
+        let matches = messages.filtered(using: NSPredicate(format: "id == %d", messageID))
+        return matches.first as? SBObject
+    }
 
     private func inboxMessagesArray() -> SBElementArray? {
         guard let app = SBApplication(bundleIdentifier: "com.apple.mail"), app.isRunning,
@@ -123,9 +144,7 @@ actor MailWorker {
     }
 
     private func messageSource(messageID: Int) -> String? {
-        guard let messages = inboxMessagesArray() else { return nil }
-        let matches = messages.filtered(using: NSPredicate(format: "id == %d", messageID))
-        guard let message = matches.first as? SBObject else { return nil }
+        guard let message = inboxMessage(withID: messageID) else { return nil }
         return (message as MailMessageSB).source
     }
 }

--- a/Unload Attachments/MailBridge.swift
+++ b/Unload Attachments/MailBridge.swift
@@ -1,0 +1,171 @@
+import Foundation
+import ScriptingBridge
+
+// Minimal typed views of Mail's scripting interface. ScriptingBridge resolves
+// these members dynamically from Mail's scripting definition at runtime; the
+// protocols only exist to satisfy the compiler.
+@objc protocol MailApplicationSB {
+    @objc optional var inbox: SBObject { get }
+}
+
+@objc protocol MailMailboxSB {
+    @objc optional func messages() -> SBElementArray
+}
+
+@objc protocol MailMessageSB {
+    @objc optional var id: Int { get }
+    @objc optional var messageId: String { get }
+    @objc optional var subject: String { get }
+    @objc optional var dateReceived: Date { get }
+    @objc optional func mailAttachments() -> SBElementArray
+}
+
+@objc protocol MailAttachmentSB {
+    @objc optional var id: String { get }
+    @objc optional var name: String { get }
+    @objc optional var fileSize: Int { get }
+}
+
+extension SBApplication: MailApplicationSB {}
+extension SBObject: MailMailboxSB, MailMessageSB, MailAttachmentSB {}
+
+struct InboxAttachment {
+    let id: String
+    let name: String
+    let fileSize: Int
+
+    var fileExtension: String {
+        (name as NSString).pathExtension.lowercased()
+    }
+}
+
+struct InboxMessage {
+    let id: Int
+    let messageID: String
+    let subject: String
+    let dateReceived: Date
+    let attachments: [InboxAttachment]
+}
+
+enum MailBridgeError: LocalizedError {
+    case scriptError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .scriptError(let message): return message
+        }
+    }
+}
+
+@MainActor
+enum MailBridge {
+
+    static var isMailRunning: Bool {
+        SBApplication(bundleIdentifier: "com.apple.mail")?.isRunning ?? false
+    }
+
+    // MARK: - Reading (ScriptingBridge)
+
+    /// Snapshots inbox messages received after the given date.
+    static func inboxMessages(receivedAfter date: Date) -> [InboxMessage] {
+        guard let app = SBApplication(bundleIdentifier: "com.apple.mail"), app.isRunning,
+              let inbox = (app as MailApplicationSB).inbox,
+              let messages = (inbox as MailMailboxSB).messages?()
+        else { return [] }
+
+        let recent = messages.filtered(using: NSPredicate(format: "dateReceived > %@", date as NSDate))
+
+        var result: [InboxMessage] = []
+        for case let message as SBObject in recent {
+            let m = message as MailMessageSB
+            guard let id = m.id, let received = m.dateReceived else { continue }
+
+            var attachments: [InboxAttachment] = []
+            if let sbAttachments = m.mailAttachments?() {
+                for case let attachment as SBObject in sbAttachments {
+                    let a = attachment as MailAttachmentSB
+                    guard let attachmentID = a.id, let name = a.name else { continue }
+                    attachments.append(InboxAttachment(id: attachmentID, name: name, fileSize: a.fileSize ?? 0))
+                }
+            }
+
+            result.append(InboxMessage(
+                id: id,
+                messageID: m.messageId ?? String(id),
+                subject: m.subject ?? "(no subject)",
+                dateReceived: received,
+                attachments: attachments
+            ))
+        }
+        return result.sorted { $0.dateReceived < $1.dateReceived }
+    }
+
+    // MARK: - Mutations (parameterized AppleScript)
+    // ScriptingBridge is unreliable for Mail's save/delete/set-content
+    // commands, so these go through small NSAppleScript snippets instead.
+
+    static func saveAttachment(messageID: Int, attachmentID: String, toFolder folder: URL) throws {
+        try run("""
+        tell application "Mail"
+            set theMessage to first message of inbox whose id is \(messageID)
+            set theAttachment to first mail attachment of theMessage whose id is \(quoted(attachmentID))
+            save theAttachment in ((POSIX file \(quoted(folder.path + "/"))) as alias)
+        end tell
+        """)
+    }
+
+    static func deleteAttachment(messageID: Int, attachmentID: String) throws {
+        try run("""
+        tell application "Mail"
+            set theMessage to first message of inbox whose id is \(messageID)
+            delete (first mail attachment of theMessage whose id is \(quoted(attachmentID)))
+        end tell
+        """)
+    }
+
+    static func messageContent(messageID: Int) throws -> String {
+        let result = try run("""
+        tell application "Mail"
+            set theMessage to first message of inbox whose id is \(messageID)
+            return content of theMessage
+        end tell
+        """)
+        return result.stringValue ?? ""
+    }
+
+    static func setMessageContent(messageID: Int, content: String) throws {
+        try run("""
+        tell application "Mail"
+            set theMessage to first message of inbox whose id is \(messageID)
+            set content of theMessage to \(quoted(content))
+        end tell
+        """)
+    }
+
+    // MARK: - Helpers
+
+    /// Escapes a Swift string into an AppleScript string literal.
+    private static func quoted(_ string: String) -> String {
+        "\"" + string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\r\n", with: "\\n")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+        + "\""
+    }
+
+    @discardableResult
+    private static func run(_ source: String) throws -> NSAppleEventDescriptor {
+        guard let script = NSAppleScript(source: source) else {
+            throw MailBridgeError.scriptError("Could not compile Mail script.")
+        }
+        var errorInfo: NSDictionary?
+        let result = script.executeAndReturnError(&errorInfo)
+        if let errorInfo {
+            let message = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown Mail scripting error."
+            throw MailBridgeError.scriptError(message)
+        }
+        return result
+    }
+}

--- a/Unload Attachments/MailBridge.swift
+++ b/Unload Attachments/MailBridge.swift
@@ -104,14 +104,29 @@ enum MailBridge {
     // ScriptingBridge is unreliable for Mail's save/delete/set-content
     // commands, so these go through small NSAppleScript snippets instead.
 
-    static func saveAttachment(messageID: Int, attachmentID: String, toFolder folder: URL) throws {
-        try run("""
-        tell application "Mail"
+    static func saveAttachment(messageID: Int, attachmentID: String, toFile file: URL) throws {
+        let lookup = """
             set theMessage to first message of inbox whose id is \(messageID)
             set theAttachment to first mail attachment of theMessage whose id is \(quoted(attachmentID))
-            save theAttachment in ((POSIX file \(quoted(folder.path + "/"))) as alias)
-        end tell
-        """)
+        """
+        do {
+            // Modern Mail expects the full destination file path.
+            try run("""
+            tell application "Mail"
+            \(lookup)
+                save theAttachment in (POSIX file \(quoted(file.path)))
+            end tell
+            """)
+        } catch {
+            // Older Mail versions instead save into a folder, keeping the
+            // attachment's original name.
+            try run("""
+            tell application "Mail"
+            \(lookup)
+                save theAttachment in ((POSIX file \(quoted(file.deletingLastPathComponent().path + "/"))) as alias)
+            end tell
+            """)
+        }
     }
 
     static func deleteAttachment(messageID: Int, attachmentID: String) throws {

--- a/Unload Attachments/MailMonitor.swift
+++ b/Unload Attachments/MailMonitor.swift
@@ -81,6 +81,10 @@ final class MailMonitor {
                 var text = "\(result.savedCount) attachment(s) unloaded from “\(result.subject)”"
                 if result.failedCount > 0 { text += " (\(result.failedCount) failed)" }
                 log(text)
+                if result.savedCount > 0 && AppSettings.flagProcessedMessages {
+                    let flagged = await worker.flagMessage(messageID: message.id)
+                    if !flagged { log("⚠ Mail did not accept the flag on “\(result.subject)”") }
+                }
                 for file in result.savedFiles {
                     log("↳ \(file.lastPathComponent)")
                 }

--- a/Unload Attachments/MailMonitor.swift
+++ b/Unload Attachments/MailMonitor.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Observation
+import UserNotifications
+
+@MainActor
+@Observable
+final class MailMonitor {
+
+    struct ActivityEntry: Identifiable {
+        let id = UUID()
+        let date: Date
+        let text: String
+    }
+
+    var isMonitoring: Bool {
+        didSet {
+            UserDefaults.standard.set(isMonitoring, forKey: SettingsKeys.monitoringEnabled)
+            if isMonitoring { startPolling() } else { stopPolling() }
+        }
+    }
+
+    private(set) var activity: [ActivityEntry] = []
+    private(set) var isProcessing = false
+    private var pollTask: Task<Void, Never>?
+
+    init() {
+        // Only mail received after the first launch is ever processed.
+        if UserDefaults.standard.object(forKey: SettingsKeys.lastProcessedDate) == nil {
+            UserDefaults.standard.set(Date().timeIntervalSinceReferenceDate,
+                                      forKey: SettingsKeys.lastProcessedDate)
+        }
+        isMonitoring = UserDefaults.standard.object(forKey: SettingsKeys.monitoringEnabled) as? Bool ?? true
+
+        do {
+            try AttachmentUnloader.ensureFoldersExist()
+        } catch {
+            log("Could not create save folder: \(error.localizedDescription)")
+        }
+
+        if isMonitoring { startPolling() }
+    }
+
+    // MARK: - Polling
+
+    private func startPolling() {
+        stopPolling()
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.pollOnce()
+                try? await Task.sleep(for: .seconds(AppSettings.pollInterval))
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    func pollOnce() async {
+        guard !isProcessing else { return }
+        guard MailBridge.isMailRunning else { return }
+        isProcessing = true
+        defer { isProcessing = false }
+
+        // Look back a little past the checkpoint so a message that arrived
+        // while a previous poll was running is not missed; the processed-ID
+        // list prevents double handling.
+        let since = lastProcessedDate.addingTimeInterval(-120)
+        let messages = MailBridge.inboxMessages(receivedAfter: since)
+
+        for message in messages {
+            guard !processedMessageIDs.contains(message.messageID) else { continue }
+
+            let hasOffice = message.attachments.contains {
+                AttachmentUnloader.officeExtensions.contains($0.fileExtension)
+            }
+            if hasOffice {
+                let result = await AttachmentUnloader.process(message)
+                var text = "\(result.savedCount) attachment(s) unloaded from “\(result.subject)”"
+                if result.failedCount > 0 { text += " (\(result.failedCount) failed)" }
+                log(text)
+                notify(about: result)
+            }
+
+            processedMessageIDs.append(message.messageID)
+            if message.dateReceived > lastProcessedDate {
+                lastProcessedDate = message.dateReceived
+            }
+        }
+    }
+
+    // MARK: - Checkpoint
+
+    private var lastProcessedDate: Date {
+        get { Date(timeIntervalSinceReferenceDate: UserDefaults.standard.double(forKey: SettingsKeys.lastProcessedDate)) }
+        set { UserDefaults.standard.set(newValue.timeIntervalSinceReferenceDate, forKey: SettingsKeys.lastProcessedDate) }
+    }
+
+    private var processedMessageIDs: [String] {
+        get { UserDefaults.standard.stringArray(forKey: SettingsKeys.processedMessageIDs) ?? [] }
+        set { UserDefaults.standard.set(Array(newValue.suffix(500)), forKey: SettingsKeys.processedMessageIDs) }
+    }
+
+    // MARK: - Feedback
+
+    private func log(_ text: String) {
+        activity.insert(ActivityEntry(date: .now, text: text), at: 0)
+        if activity.count > 20 { activity.removeLast(activity.count - 20) }
+    }
+
+    private func notify(about result: ProcessResult) {
+        Task {
+            let center = UNUserNotificationCenter.current()
+            let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
+            guard granted else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = "Unload Attachments"
+            content.subtitle = result.subject
+            content.body = "\(result.savedCount) attachment(s) saved"
+                + (result.failedCount > 0 ? ", \(result.failedCount) failed" : "")
+            try? await center.add(UNNotificationRequest(identifier: UUID().uuidString,
+                                                        content: content, trigger: nil))
+        }
+    }
+}

--- a/Unload Attachments/MailMonitor.swift
+++ b/Unload Attachments/MailMonitor.swift
@@ -59,7 +59,8 @@ final class MailMonitor {
 
     func pollOnce() async {
         guard !isProcessing else { return }
-        guard MailBridge.isMailRunning else { return }
+        let worker = MailWorker.shared
+        guard await worker.isMailRunning() else { return }
         isProcessing = true
         defer { isProcessing = false }
 
@@ -67,7 +68,7 @@ final class MailMonitor {
         // while a previous poll was running is not missed; the processed-ID
         // list prevents double handling.
         let since = lastProcessedDate.addingTimeInterval(-120)
-        let messages = MailBridge.inboxMessages(receivedAfter: since)
+        let messages = await worker.newMessages(receivedAfter: since)
 
         for message in messages {
             guard !processedMessageIDs.contains(message.messageID) else { continue }
@@ -76,7 +77,7 @@ final class MailMonitor {
                 AttachmentUnloader.officeExtensions.contains($0.fileExtension)
             }
             if hasOffice {
-                let result = await AttachmentUnloader.process(message)
+                let result = await worker.unload(message)
                 var text = "\(result.savedCount) attachment(s) unloaded from “\(result.subject)”"
                 if result.failedCount > 0 { text += " (\(result.failedCount) failed)" }
                 log(text)

--- a/Unload Attachments/MailMonitor.swift
+++ b/Unload Attachments/MailMonitor.swift
@@ -80,6 +80,9 @@ final class MailMonitor {
                 var text = "\(result.savedCount) attachment(s) unloaded from “\(result.subject)”"
                 if result.failedCount > 0 { text += " (\(result.failedCount) failed)" }
                 log(text)
+                for reason in result.failureReasons {
+                    log("⚠ \(reason)")
+                }
                 notify(about: result)
             }
 

--- a/Unload Attachments/MailMonitor.swift
+++ b/Unload Attachments/MailMonitor.swift
@@ -80,6 +80,9 @@ final class MailMonitor {
                 var text = "\(result.savedCount) attachment(s) unloaded from “\(result.subject)”"
                 if result.failedCount > 0 { text += " (\(result.failedCount) failed)" }
                 log(text)
+                for file in result.savedFiles {
+                    log("↳ \(file.lastPathComponent)")
+                }
                 for reason in result.failureReasons {
                     log("⚠ \(reason)")
                 }

--- a/Unload Attachments/Settings.swift
+++ b/Unload Attachments/Settings.swift
@@ -20,6 +20,7 @@ nonisolated enum SettingsKeys {
     static let pollInterval = "pollInterval"
     static let folderScheme = "folderScheme"
     static let parentFolderOverride = "parentFolderOverride"
+    static let flagProcessedMessages = "flagProcessedMessages"
     static let lastProcessedDate = "lastProcessedDate"
     static let processedMessageIDs = "processedMessageIDs"
 }
@@ -39,5 +40,9 @@ nonisolated enum AppSettings {
         guard let path = UserDefaults.standard.string(forKey: SettingsKeys.parentFolderOverride),
               !path.isEmpty else { return nil }
         return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    static var flagProcessedMessages: Bool {
+        UserDefaults.standard.object(forKey: SettingsKeys.flagProcessedMessages) as? Bool ?? true
     }
 }

--- a/Unload Attachments/Settings.swift
+++ b/Unload Attachments/Settings.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// How saved attachments are organized under the parent folder.
-enum FolderScheme: String, CaseIterable, Identifiable {
+nonisolated enum FolderScheme: String, CaseIterable, Identifiable {
     case byYear
     case byType
 
@@ -15,7 +15,7 @@ enum FolderScheme: String, CaseIterable, Identifiable {
     }
 }
 
-enum SettingsKeys {
+nonisolated enum SettingsKeys {
     static let monitoringEnabled = "monitoringEnabled"
     static let pollInterval = "pollInterval"
     static let folderScheme = "folderScheme"
@@ -24,7 +24,8 @@ enum SettingsKeys {
     static let processedMessageIDs = "processedMessageIDs"
 }
 
-enum AppSettings {
+// UserDefaults is thread-safe, so these reads are safe from any executor.
+nonisolated enum AppSettings {
     static var pollInterval: TimeInterval {
         let value = UserDefaults.standard.double(forKey: SettingsKeys.pollInterval)
         return value > 0 ? value : 30

--- a/Unload Attachments/Settings.swift
+++ b/Unload Attachments/Settings.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// How saved attachments are organized under the parent folder.
+enum FolderScheme: String, CaseIterable, Identifiable {
+    case byYear
+    case byType
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .byYear: return "By Year"
+        case .byType: return "By Type"
+        }
+    }
+}
+
+enum SettingsKeys {
+    static let monitoringEnabled = "monitoringEnabled"
+    static let pollInterval = "pollInterval"
+    static let folderScheme = "folderScheme"
+    static let parentFolderOverride = "parentFolderOverride"
+    static let lastProcessedDate = "lastProcessedDate"
+    static let processedMessageIDs = "processedMessageIDs"
+}
+
+enum AppSettings {
+    static var pollInterval: TimeInterval {
+        let value = UserDefaults.standard.double(forKey: SettingsKeys.pollInterval)
+        return value > 0 ? value : 30
+    }
+
+    static var folderScheme: FolderScheme {
+        FolderScheme(rawValue: UserDefaults.standard.string(forKey: SettingsKeys.folderScheme) ?? "") ?? .byYear
+    }
+
+    static var parentFolderOverride: URL? {
+        guard let path = UserDefaults.standard.string(forKey: SettingsKeys.parentFolderOverride),
+              !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+}

--- a/Unload Attachments/Unload_AttachmentsApp.swift
+++ b/Unload Attachments/Unload_AttachmentsApp.swift
@@ -18,6 +18,7 @@ struct MenuContentView: View {
 
     @AppStorage(SettingsKeys.pollInterval) private var pollInterval = 30.0
     @AppStorage(SettingsKeys.folderScheme) private var folderScheme = FolderScheme.byYear.rawValue
+    @AppStorage(SettingsKeys.flagProcessedMessages) private var flagProcessedMessages = true
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
     var body: some View {
@@ -52,6 +53,8 @@ struct MenuContentView: View {
                 Text(scheme.label).tag(scheme.rawValue)
             }
         }
+
+        Toggle("Flag Processed Emails", isOn: $flagProcessedMessages)
 
         Button("Open Save Folder") {
             try? AttachmentUnloader.ensureFoldersExist()

--- a/Unload Attachments/Unload_AttachmentsApp.swift
+++ b/Unload Attachments/Unload_AttachmentsApp.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import AppKit
+import ServiceManagement
+
+@main
+struct Unload_AttachmentsApp: App {
+    @State private var monitor = MailMonitor()
+
+    var body: some Scene {
+        MenuBarExtra("Unload Attachments", systemImage: "tray.and.arrow.down") {
+            MenuContentView(monitor: monitor)
+        }
+    }
+}
+
+struct MenuContentView: View {
+    @Bindable var monitor: MailMonitor
+
+    @AppStorage(SettingsKeys.pollInterval) private var pollInterval = 30.0
+    @AppStorage(SettingsKeys.folderScheme) private var folderScheme = FolderScheme.byYear.rawValue
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+
+    var body: some View {
+        Toggle("Monitor for New Mail", isOn: $monitor.isMonitoring)
+
+        Button("Process Inbox Now") {
+            Task { await monitor.pollOnce() }
+        }
+        .disabled(monitor.isProcessing)
+
+        Divider()
+
+        if monitor.activity.isEmpty {
+            Text("No attachments unloaded yet")
+        } else {
+            ForEach(monitor.activity.prefix(5)) { entry in
+                Text("\(entry.date.formatted(date: .omitted, time: .shortened)) — \(entry.text)")
+            }
+        }
+
+        Divider()
+
+        Picker("Check Every", selection: $pollInterval) {
+            Text("15 seconds").tag(15.0)
+            Text("30 seconds").tag(30.0)
+            Text("1 minute").tag(60.0)
+            Text("5 minutes").tag(300.0)
+        }
+
+        Picker("Organize Files", selection: $folderScheme) {
+            ForEach(FolderScheme.allCases) { scheme in
+                Text(scheme.label).tag(scheme.rawValue)
+            }
+        }
+
+        Button("Open Save Folder") {
+            try? AttachmentUnloader.ensureFoldersExist()
+            NSWorkspace.shared.open(AttachmentUnloader.parentFolder)
+        }
+
+        Button("Choose Save Folder…") {
+            chooseParentFolder()
+        }
+
+        Divider()
+
+        Toggle("Launch at Login", isOn: $launchAtLogin)
+            .onChange(of: launchAtLogin) { _, enabled in
+                do {
+                    if enabled {
+                        try SMAppService.mainApp.register()
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                    }
+                } catch {
+                    launchAtLogin = SMAppService.mainApp.status == .enabled
+                }
+            }
+
+        Divider()
+
+        Button("Quit Unload Attachments") {
+            NSApplication.shared.terminate(nil)
+        }
+    }
+
+    private func chooseParentFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Use This Folder"
+        panel.message = "Attachments will be saved into year or type subfolders of the chosen folder."
+        NSApp.activate(ignoringOtherApps: true)
+        if panel.runModal() == .OK, let url = panel.url {
+            UserDefaults.standard.set(url.path, forKey: SettingsKeys.parentFolderOverride)
+            try? AttachmentUnloader.ensureFoldersExist()
+        }
+    }
+}


### PR DESCRIPTION
Replaces the manual AppleScript workflow with a Swift background app.

## What it does
- Menu bar agent (no Dock icon) polls Mail's inbox for new messages on a configurable interval
- Office/PDF attachments from new mail are extracted and saved to iCloud-synced `Documents/unloader-files/`, organized by year or by type (user setting)
- Processed messages get a green flag in Mail (toggleable); flags sync to iPhone
- Notifications and a menu activity log report every save and failure
- Launch-at-login, custom save folder, pause/resume

## Notable engineering findings
- Modern Mail rejects **all** scripted modifications of received messages (save/delete attachment, set content) with error -10000, so attachments are extracted by MIME-decoding the raw message source instead
- All Mail I/O runs on a dedicated `MailWorker` actor so Apple-event round trips never block the menu bar UI
- Flag status is message metadata, which Mail still allows scripts to change — verified by read-back

The original `Unload.applescript` remains in the repo as historical reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)