### PR TITLE
Update README status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,4 @@ in-email links that work from any device. See
 
 ## Status
 
-Actively developed. The IMAP backend lives on the `imap-backend` branch
-pending merge to `main`.
+Actively developed.


### PR DESCRIPTION
## Summary
- README's Status section referenced a stale `imap-backend` branch that has since merged to `main`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>